### PR TITLE
Change auto-update to not restart the node if the version changed

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -36,6 +36,8 @@ services:
       - --proverAgent.proverAgentPollIntervalMs
       - ${PROVER_AGENT_POLL_INTERVAL_MS}
       - --prover-agent
+      - --auto-update
+      - config
     <<: *logging
     labels:
       - "com.centurylinklabs.watchtower.enable=${AZTEC_AUTOUPDATE:-false}"

--- a/broker.yml
+++ b/broker.yml
@@ -33,6 +33,8 @@ services:
       - --l1-rpc-urls
       - ${L1_RPC}
       - --prover-broker
+      - --auto-update
+      - config
     <<: *logging
     labels:
       - "com.centurylinklabs.watchtower.enable=${AZTEC_AUTOUPDATE:-false}"
@@ -82,6 +84,8 @@ services:
       - ${L1_WALLET_PRIVATE_KEY}
       - --prover-node
       - --archiver
+      - --auto-update
+      - config
     <<: *logging
     labels:
       - "com.centurylinklabs.watchtower.enable=${AZTEC_AUTOUPDATE:-false}"

--- a/validator.yml
+++ b/validator.yml
@@ -47,6 +47,8 @@ services:
       - --node
       - --archiver
       - --sequencer
+      - --auto-update
+      - config
     command: ${SEQUENCER_EXTRAS}
     <<: *logging
     labels:


### PR DESCRIPTION
And rely on watchtower to handle this instead. This is because docker compose doesn't use the pull-policy when a container quits, unlike k8s