### PR TITLE
Fix watchtower parameters

### DIFF
--- a/watchtower.yml
+++ b/watchtower.yml
@@ -18,4 +18,3 @@ services:
       - --interval
       - "600"
       - --include-restarting
-      - "true"


### PR DESCRIPTION
"true" was being interpreted as a name, not as the value for `--include-restarting`