### PR TITLE
Multiple validators in one sequencer process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,22 @@ If you want the broker node port exposed unencrypted to the host, use `broker-sh
 
 ## Quick setup for Sequencer / Validator
 
-Run `cp default.env .env`, then `nano .env`, and update values like `L1_RPC`, `L1_REST`, `VALIDATOR_PRIVATE_KEY`,
-`COINBASE`, and the `NETWORK` as well as the `BLOB_SINK_URL` and `PUBLIC_IP_ADDRESS`.
+Run `cp default.env .env`, then `nano .env`, and update values like `L1_RPC`, `L1_REST`, `VALIDATOR_PRIVATE_KEYS`,
+`L1_WALLET_PRIVATE_KEY`, `COINBASE`, and the `NETWORK` as well as the `PUBLIC_IP_ADDRESS`.
 
-`VALIDATOR_PRIVATE_KEY` is the private key of an L1 wallet, and will be used to pay gas. `COINBASE` is its public
-address.
+`L1_WALLET_PRIVATE_KEY` is the private key of an L1 wallet, and will be used to pay gas. `COINBASE` is its public
+address. This is the only wallet that needs to have ETH, even when multiple validators are active via the parameter
+below.
+
+`VALIDATOR_PRIVATE_KEYS` is a comma-separated list of L1 wallet private keys, one for each validator that should
+be run by the sequencer/validator process.
 
 Make sure that `COMPOSE_FILE` includes `validator.yml`
 
 Wait for the validator to be fully synced: Check with `./aztecd logs -f validator` and look for a message telling
 you that it's up and listening on the aztec port 8080, and has peers.
+
+NB: Registration is changing, README will be updated with new instructions
 
 Register the validator - Sepolia testnet only, a more flexible version is to be created:
 `./aztecd cmd run -it --rm register-validator`
@@ -71,4 +77,4 @@ add it to `COMPOSE_FILE` in `.env`
 
 Aztec Prover Docker uses a semver scheme.
 
-This is Aztec Prover Docker v1.1.0
+This is Aztec Prover Docker v2.0.0

--- a/default.env
+++ b/default.env
@@ -1,12 +1,12 @@
 # Do not update default.env directly - copy it to .env and nano .env
 # Which components to run: Agent, broker, and/or validator/sequencer
-COMPOSE_FILE=agent.yml:broker.yml:watchtower.yml
+COMPOSE_FILE=agent.yml:broker.yml
 
 AZTEC_REPO=aztecprotocol/aztec
 AZTEC_TAG=latest
 # Whether watchtower should automatically pull new versions of the avove tag when available
 # Also requires watchtower.yml in COMPOSE_FILE, or a watchtower service running on the host at all
-AZTEC_AUTOUPDATE=true
+AZTEC_AUTOUPDATE=false
 
 # Parameters for broker and/or validator
 NETWORK=alpha-testnet
@@ -23,8 +23,6 @@ BLOB_SINK_URL=
 OTEL_METRICS_ENDPOINT=
 
 # Parameters when running a node via broker.yml; not needed for agent or validator
-# Private key of an L1 wallet, for gas
-L1_WALLET_PRIVATE_KEY=
 #L1_FIXED_PRIORITY_FEE_PER_GAS=3
 #L1_GAS_LIMIT_BUFFER_PERCENTAGE=15
 #L1_GAS_PRICE_MAX=500
@@ -33,11 +31,15 @@ BROKER_PORT=8080
 # P2P port the node uses, host-mapped and Internet-reachable
 P2P_PORT=40400
 
+# Parameters when running a sequencer/validator or broker/node
+# Private key of an L1 wallet, for gas. For a sequencer, this will be used to pay gas for all validators
+L1_WALLET_PRIVATE_KEY=
+
 # Parameters when running a sequencer/validator; not needed for agent or broker
 # Public address of an Ethereum wallet
 COINBASE=
-# Private key of an L1 wallet, for gas
-VALIDATOR_PRIVATE_KEY=
+# Private key(s) of L1 wallets, comma-separated, one for each sequencer/validator
+VALIDATOR_PRIVATE_KEYS=
 # P2P port the validator uses, host-mapped and Internet-reachable
 VALIDATOR_P2P_PORT=40500
 # Additional command line parameters to pass to the sequencer
@@ -72,4 +74,4 @@ LOG_LEVEL=info
 SCRIPT_TAG=
 
 # Used by aztecd update - please do not adjust
-ENV_VERSION=6
+ENV_VERSION=7

--- a/ethd
+++ b/ethd
@@ -45,8 +45,8 @@ __env_migrate() {
     return 0
   fi
 
-  __old_vars=( )
-  __new_vars=( )
+  __old_vars=( VALIDATOR_PRIVATE_KEY )
+  __new_vars=( VALIDATOR_PRIVATE_KEYS )
 
   __var=ENV_VERSION
   __get_value_from_env "${__var}" "default.env" "__target_ver"

--- a/validator.yml
+++ b/validator.yml
@@ -40,8 +40,10 @@ services:
       - ${L1_RPC}
       - --l1-consensus-host-urls
       - ${L1_REST}
-      - --sequencer.validatorPrivateKey
-      - ${VALIDATOR_PRIVATE_KEY}
+      - --sequencer.validatorPrivateKeys
+      - ${VALIDATOR_PRIVATE_KEYS}
+      - --sequencer.publisherPrivateKey
+      - ${L1_WALLET_PRIVATE_KEY}
       - --sequencer.coinbase
       - ${COINBASE}
       - --node


### PR DESCRIPTION
This is a breaking change and requires v1.1.0. Use comma-separated `VALIDATOR_PRIVATE_KEYS` for the validator keys, and `L1_WALLET_PRIVATE_KEY` to pay gas. Using `L1_WALLET_PRIVATE_KEY` in `validator.yml` is new, and that makes this a breaking change: If it's not set, the process will fail to start.

Also disable auto-update by default, as relying on `latest` tag has proven to be brittle

