### PR TITLE
space grep more accurate

### DIFF
--- a/ethd
+++ b/ethd
@@ -610,7 +610,7 @@ __display_docker_volumes() {
     echo
   else
     echo "Here are the Docker volumes used by this copy of ${__project_name} and their space usage:"
-    __dodocker system df -v | grep -A 500 "VOLUME NAME" | grep "^$(basename "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
+    __dodocker system df -v | grep -A 500 "VOLUME NAME" | grep -E "^$(basename "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")_[^_]+"
     echo
   fi
   echo "If there is some mystery space being taken up, try \"sudo ncdu /\"."


### PR DESCRIPTION
aztec-prover and aztec-prover2 will each only show their respective volumes. A little brittle, assumes the directory name has no `_` and that Docker always uses `_` between project name and volume name.