### PR TITLE
Do not write core dump files

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -22,6 +22,8 @@ services:
         limits:
           cpus: ${PROVER_AGENT_CPUS:-32}
           memory: ${PROVER_AGENT_MEM:-128G}
+    ulimits:
+      core: 0  # Workaround for filling disk with cores
     entrypoint:
       - node
       - --no-warnings


### PR DESCRIPTION
A portion of the agent core dumps, appears to be an uncaught C exception, not an OOM. This fills disk on Debian 13 where core files have the pid appended; on Debian 12 they're all just `core`

```
/usr/src/yarn-project/core.10625: ELF 64-bit LSB core file, x86-64, version 1 (SYSV), SVR4-style, from '/usr/src/barretenberg/cpp/build/bin/bb avm_prove --avm-inputs /usr/src/bb/tmp-L', real uid: 0, effective uid: 0, real gid: 0, effective gid: 0, execfn: '/usr/src/barretenberg/cpp/build/bin/bb', platform: 'x86_64'
```
