### PR TITLE
BCE-10711 use staking registry for provider queue

### DIFF
--- a/provider-monitor/README.md
+++ b/provider-monitor/README.md
@@ -24,7 +24,7 @@ alert thresholds, severity, routing, and no-data behavior.
 | `NETWORK` | `mainnet` | Network used to select default contract addresses |
 | `MONITOR_POLL_INTERVAL` | `300` | Seconds between provider queue polls |
 | `METRICS_PORT` | `9102` | Prometheus metrics port |
-| `PROVIDER_QUEUE_CONTRACT_ADDRESS` | network default | Optional override for the queue contract address |
+| `PROVIDER_QUEUE_CONTRACT_ADDRESS` | network default | Optional override for the staking registry address. Required for networks without a verified default. |
 | `LOG_LEVEL` | `INFO` | Logging level |
 | `RPC_TIMEOUT` | `30` | Per-RPC timeout in seconds |
 

--- a/provider-monitor/monitor.py
+++ b/provider-monitor/monitor.py
@@ -25,16 +25,13 @@ RPC_TIMEOUT = int(os.getenv("RPC_TIMEOUT", "30"))
 
 CONTRACTS = {
     "mainnet": {
-        "rollup": "0xAe2001f7e21d5EcABf6234E9FDd1E76F50F74962",
-    },
-    "testnet": {
-        "rollup": "0x66A41CB55F9a1e38A45A2Ac8685F12A61fBFab77",
+        "staking_registry": "0x042dF8f42790d6943F41C25C2132400fd727f452",
     },
 }
 
 PROVIDER_QUEUE_CONTRACT_ADDRESS = os.getenv(
     "PROVIDER_QUEUE_CONTRACT_ADDRESS",
-    CONTRACTS.get(NETWORK, {}).get("rollup", ""),
+    CONTRACTS.get(NETWORK, {}).get("staking_registry", ""),
 )
 
 QUEUE_LENGTH_SIGNATURES = (

--- a/provider-monitor/test_monitor.py
+++ b/provider-monitor/test_monitor.py
@@ -18,6 +18,12 @@ import monitor
 
 
 class ProviderMonitorTests(unittest.TestCase):
+    def test_mainnet_default_uses_staking_registry(self):
+        self.assertEqual(
+            monitor.PROVIDER_QUEUE_CONTRACT_ADDRESS,
+            "0x042dF8f42790d6943F41C25C2132400fd727f452",
+        )
+
     def test_parse_rpc_urls(self):
         self.assertEqual(
             monitor.parse_rpc_urls(" https://a.example,https://b.example, "),


### PR DESCRIPTION
## Summary
- point the provider monitor default at the verified mainnet staking registry for provider queue reads
- require an explicit override for networks without a verified default
- add a regression test for the mainnet default address
