### PR TITLE
BCE-10711 combine provider monitor and coinbase updater

### DIFF
--- a/default.env
+++ b/default.env
@@ -72,11 +72,15 @@ DOCKER_EXT_NETWORK=traefik_default
 # info, warn, error, trace
 LOG_LEVEL=info
 
-# Provider Monitor - exports read-only provider metrics
-# Your provider ID
+# Provider Monitor - updates coinbase addresses and exports provider metrics
+# Your provider ID on the Staking Dashboard
 PROVIDER_ID=
-# How often to poll provider state (seconds)
-MONITOR_POLL_INTERVAL=300
+# Staking Dashboard API URL
+STAKING_API_URL=
+# How often to poll for provider updates and queue metrics (seconds)
+MONITOR_POLL_INTERVAL=10800
+# Slack webhook URL for coinbase update notifications (optional)
+SLACK_WEBHOOK_URL=
 # Provider monitor Prometheus metrics port
 PROVIDER_MONITOR_METRICS_PORT=9102
 

--- a/provider-monitor.yml
+++ b/provider-monitor.yml
@@ -12,11 +12,18 @@ services:
     build:
       context: ./provider-monitor
       dockerfile: Dockerfile
+    volumes:
+      - ./aztec-validator-keystore:/keystore
+      - coinbase-monitor-data:/data
     environment:
       PROVIDER_ID: ${PROVIDER_ID}
+      STAKING_API_URL: ${STAKING_API_URL}
+      MONITOR_POLL_INTERVAL: ${MONITOR_POLL_INTERVAL:-10800}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
+      KEYSTORE_PATH: /keystore
+      DATA_PATH: /data
       L1_RPC_URL: ${L1_RPC}
       NETWORK: ${NETWORK:-mainnet}
-      MONITOR_POLL_INTERVAL: ${MONITOR_POLL_INTERVAL:-300}
       METRICS_PORT: ${PROVIDER_MONITOR_METRICS_PORT:-9102}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     labels:
@@ -24,3 +31,6 @@ services:
       - metrics.path=/metrics
       - metrics.port=${PROVIDER_MONITOR_METRICS_PORT:-9102}
     <<: *logging
+
+volumes:
+  coinbase-monitor-data:

--- a/provider-monitor/Dockerfile
+++ b/provider-monitor/Dockerfile
@@ -9,4 +9,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application
 COPY monitor.py .
 
+# Create directories for volumes (will be mounted over)
+RUN mkdir -p /keystore /data
+
 CMD ["python", "-u", "monitor.py"]

--- a/provider-monitor/README.md
+++ b/provider-monitor/README.md
@@ -1,32 +1,56 @@
 # Aztec Provider Monitor
 
-Read-only Prometheus exporter for Aztec provider-level metrics.
+Provider monitor for Aztec validators.
 
-The monitor currently polls the L1 provider queue length with
-`getProviderQueueLength(PROVIDER_ID)` and exposes raw metrics. Grafana owns
-alert thresholds, severity, routing, and no-data behavior.
+The service keeps the existing coinbase updater behavior and also exports
+provider-level Prometheus metrics:
+
+- Fetches provider stake data from the Staking Dashboard API.
+- Updates `aztec-validator-keystore/sequencers.json` coinbase addresses to the
+  matching split contract addresses.
+- Sends Slack notifications for new delegations, coinbase updates, and repeated
+  updater errors when `SLACK_WEBHOOK_URL` is configured.
+- Polls the L1 staking registry with `getProviderQueueLength(PROVIDER_ID)`.
+- Exposes raw metrics for Grafana alerting.
+
+Grafana owns metric alert thresholds, severity, routing, and no-data behavior.
+The compose volume and persisted mapping files keep their existing names:
+`coinbase-monitor-data`, `coinbase-monitor-state.json`, and
+`coinbase-mappings.json`. This preserves updater state across the service
+rename.
 
 ## Metrics
 
 | Metric | Description |
 | --- | --- |
 | `aztec_provider_sequencer_key_queue_length{provider_id}` | Current provider sequencer key queue length |
-| `aztec_provider_queue_last_success_timestamp{provider_id}` | Unix timestamp of the last successful queue poll |
+| `aztec_provider_queue_last_success_timestamp{provider_id}` | Unix timestamp of the last successful provider queue poll |
 | `aztec_provider_queue_poll_errors_total{provider_id}` | Total failed provider queue polls |
 | `aztec_provider_queue_up{provider_id}` | Latest queue poll status, `1` for success and `0` for failure |
+| `aztec_provider_coinbase_update_up{provider_id}` | Latest coinbase updater status, `1` for success and `0` for failure |
+| `aztec_provider_coinbase_update_last_success_timestamp{provider_id}` | Unix timestamp of the last successful coinbase updater check |
+| `aztec_provider_coinbase_updates_total{provider_id}` | Total coinbase updates written to `sequencers.json` |
+| `aztec_provider_coinbase_update_errors_total{provider_id}` | Total coinbase updater errors |
 
 ## Configuration
 
 | Environment Variable | Default | Description |
 | --- | --- | --- |
 | `PROVIDER_ID` | `` | Aztec provider ID to monitor |
+| `STAKING_API_URL` | `` | Staking Dashboard API base URL |
 | `L1_RPC_URL` | `` | L1 RPC URL list, comma-separated |
 | `NETWORK` | `mainnet` | Network used to select default contract addresses |
-| `MONITOR_POLL_INTERVAL` | `300` | Seconds between provider queue polls |
-| `METRICS_PORT` | `9102` | Prometheus metrics port |
+| `MONITOR_POLL_INTERVAL` | `10800` | Seconds between coinbase update checks and provider queue metric polls |
+| `PROVIDER_MONITOR_METRICS_PORT` | `9102` | Compose-level Prometheus metrics port and scrape label |
+| `METRICS_PORT` | `9102` | Container/script Prometheus metrics port, normally set by compose |
 | `PROVIDER_QUEUE_CONTRACT_ADDRESS` | network default | Optional override for the staking registry address. Required for networks without a verified default. |
+| `SLACK_WEBHOOK_URL` | `` | Optional Slack webhook for coinbase updater notifications |
+| `KEYSTORE_PATH` | `/keystore` | Path containing `sequencers.json` |
+| `DATA_PATH` | `/data` | Path for updater state and mapping files |
 | `LOG_LEVEL` | `INFO` | Logging level |
 | `RPC_TIMEOUT` | `30` | Per-RPC timeout in seconds |
+| `ERROR_ALERT_THRESHOLD` | `3` | Consecutive updater failures before Slack alerting |
+| `ERROR_ALERT_COOLDOWN` | `3600` | Seconds between repeated updater error Slack alerts |
 
 ## Running With Validator
 
@@ -47,8 +71,13 @@ docker compose up -d
 ```bash
 cd provider-monitor
 pip install -r requirements.txt
+mkdir -p /tmp/aztec-provider-monitor-keystore /tmp/aztec-provider-monitor-data
+printf '{"schemaVersion":1,"validators":[]}\n' > /tmp/aztec-provider-monitor-keystore/sequencers.json
 PROVIDER_ID=74 \
+STAKING_API_URL=https://staking-api.example/api \
 L1_RPC_URL=https://ethereum-rpc.example \
+KEYSTORE_PATH=/tmp/aztec-provider-monitor-keystore \
+DATA_PATH=/tmp/aztec-provider-monitor-data \
 NETWORK=mainnet \
 python monitor.py
 ```

--- a/provider-monitor/monitor.py
+++ b/provider-monitor/monitor.py
@@ -2,26 +2,42 @@
 """
 Aztec Provider Monitor
 
-Polls Aztec L1 contracts for provider-level state and exposes raw Prometheus
-metrics. Alert thresholds and routing are owned by Grafana.
+Maintains provider coinbase address mappings in sequencers.json and exposes
+provider-level Prometheus metrics. Grafana owns metric alert thresholds and
+routing; Slack notifications remain for coinbase updater events.
 """
 
+import json
 import logging
 import os
 import sys
 import time
-from typing import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
 
+import requests
 from prometheus_client import Counter, Gauge, start_http_server
 from web3 import Web3
 
 PROVIDER_ID = os.getenv("PROVIDER_ID", "")
+STAKING_API_URL = os.getenv("STAKING_API_URL", "")
 L1_RPC_URL = os.getenv("L1_RPC_URL", "")
 NETWORK = os.getenv("NETWORK", "mainnet").lower()
-MONITOR_POLL_INTERVAL = int(os.getenv("MONITOR_POLL_INTERVAL", "300"))
+MONITOR_POLL_INTERVAL = int(os.getenv("MONITOR_POLL_INTERVAL", "10800"))
 METRICS_PORT = int(os.getenv("METRICS_PORT", "9102"))
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
+KEYSTORE_PATH = os.getenv("KEYSTORE_PATH", "/keystore")
+DATA_PATH = os.getenv("DATA_PATH", "/data")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 RPC_TIMEOUT = int(os.getenv("RPC_TIMEOUT", "30"))
+
+ERROR_ALERT_THRESHOLD = int(os.getenv("ERROR_ALERT_THRESHOLD", "3"))
+ERROR_ALERT_COOLDOWN = int(os.getenv("ERROR_ALERT_COOLDOWN", "3600"))
+
+SEQUENCERS_FILE = Path(KEYSTORE_PATH) / "sequencers.json"
+STATE_FILE = Path(DATA_PATH) / "coinbase-monitor-state.json"
+MAPPINGS_FILE = Path(DATA_PATH) / "coinbase-mappings.json"
 
 CONTRACTS = {
     "mainnet": {
@@ -48,6 +64,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+error_state = {
+    "consecutive_failures": 0,
+    "last_error_alert_time": 0,
+    "last_error_type": None,
+    "was_in_error_state": False,
+}
+
 PROVIDER_QUEUE_LENGTH = Gauge(
     "aztec_provider_sequencer_key_queue_length",
     "Current available sequencer key queue length for an Aztec provider",
@@ -68,6 +91,431 @@ PROVIDER_QUEUE_UP = Gauge(
     "Whether the Aztec provider queue poll succeeded on the latest attempt (1=yes, 0=no)",
     ["provider_id"],
 )
+COINBASE_UPDATE_UP = Gauge(
+    "aztec_provider_coinbase_update_up",
+    "Whether the latest provider coinbase update check succeeded (1=yes, 0=no)",
+    ["provider_id"],
+)
+COINBASE_UPDATE_LAST_SUCCESS = Gauge(
+    "aztec_provider_coinbase_update_last_success_timestamp",
+    "Unix timestamp of the last successful provider coinbase update check",
+    ["provider_id"],
+)
+COINBASE_UPDATES_TOTAL = Counter(
+    "aztec_provider_coinbase_updates_total",
+    "Total number of provider coinbase address updates written to sequencers.json",
+    ["provider_id"],
+)
+COINBASE_UPDATE_ERRORS = Counter(
+    "aztec_provider_coinbase_update_errors_total",
+    "Total number of provider coinbase updater errors",
+    ["provider_id"],
+)
+
+
+def send_slack_notification(message: str, blocks: list[dict] | None = None) -> bool:
+    """Send a notification to Slack webhook."""
+    if not SLACK_WEBHOOK_URL:
+        logger.debug("Slack webhook URL not configured, skipping notification")
+        return False
+
+    try:
+        payload: dict[str, Any] = {"text": message}
+        if blocks:
+            payload["blocks"] = blocks
+
+        response = requests.post(SLACK_WEBHOOK_URL, json=payload, timeout=10)
+        response.raise_for_status()
+        logger.info("Slack notification sent successfully")
+        return True
+    except requests.RequestException as exc:
+        logger.error("Failed to send Slack notification: %s", exc)
+        return False
+
+
+def send_error_alert(error_type: str, error_message: str) -> None:
+    """Send Slack alert for repeated coinbase updater errors."""
+    error_state["consecutive_failures"] += 1
+    error_state["last_error_type"] = error_type
+
+    current_time = time.time()
+    time_since_last_alert = current_time - error_state["last_error_alert_time"]
+    should_alert = (
+        error_state["consecutive_failures"] >= ERROR_ALERT_THRESHOLD
+        and time_since_last_alert >= ERROR_ALERT_COOLDOWN
+    )
+
+    if not should_alert:
+        return
+
+    message = (
+        "Aztec Provider Monitor Error\n\n"
+        f"Provider ID: {PROVIDER_ID}\n"
+        f"Error Type: {error_type}\n\n"
+        f"{error_message}\n\n"
+        f"Consecutive failures: {error_state['consecutive_failures']}\n"
+        f"Will retry in {MONITOR_POLL_INTERVAL} seconds."
+    )
+    if send_slack_notification(message):
+        error_state["last_error_alert_time"] = current_time
+        error_state["was_in_error_state"] = True
+
+
+def send_recovery_alert() -> None:
+    """Send Slack alert when the coinbase updater recovers from errors."""
+    if error_state["was_in_error_state"] and error_state["consecutive_failures"] > 0:
+        failures = error_state["consecutive_failures"]
+        message = (
+            "Aztec Provider Monitor Recovered\n\n"
+            f"Provider ID: {PROVIDER_ID}\n"
+            f"Service resumed normal operation after {failures} failed attempt(s)."
+        )
+        send_slack_notification(message)
+
+    error_state["consecutive_failures"] = 0
+    error_state["last_error_type"] = None
+    error_state["was_in_error_state"] = False
+
+
+def fetch_provider_data() -> tuple[dict[str, Any] | None, str | None]:
+    """
+    Fetch provider data from the Staking Dashboard API.
+
+    Returns a tuple of (data, error_message). If successful, error_message is None.
+    """
+    url = f"{STAKING_API_URL.rstrip('/')}/providers/{PROVIDER_ID}"
+
+    try:
+        logger.debug("Fetching provider data from %s", url)
+        response = requests.get(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+                "Accept": "application/json",
+                "Origin": "https://staking.aztec.network",
+                "Referer": "https://staking.aztec.network/",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json(), None
+    except requests.Timeout:
+        error_msg = f"Request timeout after 30s: {url}"
+        logger.error(error_msg)
+        return None, error_msg
+    except requests.ConnectionError as exc:
+        error_msg = f"Connection error: {exc}"
+        logger.error(error_msg)
+        return None, error_msg
+    except requests.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response is not None else "unknown"
+        error_msg = f"HTTP error {status_code}: {exc}"
+        logger.error(error_msg)
+        return None, error_msg
+    except requests.RequestException as exc:
+        error_msg = f"Request failed: {exc}"
+        logger.error(error_msg)
+        return None, error_msg
+    except json.JSONDecodeError as exc:
+        error_msg = f"JSON parse error: {exc}"
+        logger.error(error_msg)
+        return None, error_msg
+
+
+def load_sequencers() -> tuple[dict[str, Any] | None, str | None]:
+    """Load sequencers.json."""
+    if not SEQUENCERS_FILE.exists():
+        error_msg = f"Sequencers file not found: {SEQUENCERS_FILE}"
+        logger.error(error_msg)
+        return None, error_msg
+
+    try:
+        with open(SEQUENCERS_FILE, "r") as file_handle:
+            return json.load(file_handle), None
+    except json.JSONDecodeError as exc:
+        error_msg = f"Failed to parse sequencers.json: {exc}"
+        logger.error(error_msg)
+        return None, error_msg
+    except OSError as exc:
+        error_msg = f"Failed to read sequencers.json: {exc}"
+        logger.error(error_msg)
+        return None, error_msg
+
+
+def save_sequencers(data: dict[str, Any]) -> tuple[bool, str | None]:
+    """Save sequencers.json."""
+    try:
+        with open(SEQUENCERS_FILE, "w") as file_handle:
+            json.dump(data, file_handle, indent=2)
+        logger.info("Sequencers file saved: %s", SEQUENCERS_FILE)
+        return True, None
+    except OSError as exc:
+        error_msg = f"Failed to save sequencers.json: {exc}"
+        logger.error(error_msg)
+        return False, error_msg
+
+
+def load_state() -> dict[str, Any]:
+    """Load the coinbase updater state file."""
+    if not STATE_FILE.exists():
+        return {"known_stakes": {}, "last_updated": None}
+
+    try:
+        with open(STATE_FILE, "r") as file_handle:
+            return json.load(file_handle)
+    except (json.JSONDecodeError, OSError):
+        return {"known_stakes": {}, "last_updated": None}
+
+
+def save_state(state: dict[str, Any]) -> None:
+    """Save the coinbase updater state file."""
+    state["last_updated"] = datetime.now(timezone.utc).isoformat()
+    try:
+        with open(STATE_FILE, "w") as file_handle:
+            json.dump(state, file_handle, indent=2)
+    except OSError as exc:
+        logger.error("Failed to save state file: %s", exc)
+
+
+def save_mappings(mappings: list[dict[str, Any]]) -> None:
+    """Save the coinbase mappings file for reference."""
+    data = {
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "provider_id": PROVIDER_ID,
+        "mappings": mappings,
+    }
+    try:
+        with open(MAPPINGS_FILE, "w") as file_handle:
+            json.dump(data, file_handle, indent=2)
+        logger.debug("Mappings file saved: %s", MAPPINGS_FILE)
+    except OSError as exc:
+        logger.error("Failed to save mappings file: %s", exc)
+
+
+def normalize_address(addr: str | None) -> str:
+    """Normalize Ethereum address to lowercase for comparison."""
+    return addr.lower() if addr else ""
+
+
+def process_stakes(
+    provider_data: dict[str, Any],
+    state: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    Process stakes from API data and identify new or changed mappings.
+
+    Returns a tuple of (all_mappings, new_or_changed_mappings).
+    """
+    stakes = provider_data.get("stakes", [])
+    known_stakes = state.get("known_stakes", {})
+
+    all_mappings = []
+    new_or_changed = []
+
+    for stake in stakes:
+        attester_address = stake.get("attesterAddress", "")
+        split_contract = stake.get("splitContractAddress", "")
+        staked_amount = stake.get("stakedAmount", "0")
+
+        if not attester_address or not split_contract:
+            continue
+
+        mapping = {
+            "attester_address": attester_address,
+            "split_contract": split_contract,
+            "previous_split_contract": known_stakes.get(normalize_address(attester_address), ""),
+            "staked_amount": staked_amount,
+            "staker_address": stake.get("stakerAddress", ""),
+            "tx_hash": stake.get("txHash", ""),
+            "block_number": stake.get("blockNumber", ""),
+        }
+        all_mappings.append(mapping)
+
+        key = normalize_address(attester_address)
+        known_split = known_stakes.get(key, "")
+
+        if normalize_address(known_split) != normalize_address(split_contract):
+            new_or_changed.append(mapping)
+            known_stakes[key] = split_contract
+
+    state["known_stakes"] = known_stakes
+    return all_mappings, new_or_changed
+
+
+def update_sequencers_coinbase(
+    mappings: list[dict[str, Any]],
+) -> tuple[int, list[dict[str, Any]], str | None]:
+    """
+    Update coinbase addresses in sequencers.json.
+
+    Returns a tuple of (number_of_updates, changes, error_message).
+    """
+    sequencers_data, error = load_sequencers()
+    if not sequencers_data:
+        return 0, [], error
+
+    mapping_lookup = {}
+    for mapping in mappings:
+        mapping_lookup[normalize_address(mapping["attester_address"])] = mapping
+
+        previous_split = normalize_address(mapping.get("previous_split_contract"))
+        if previous_split:
+            mapping_lookup[previous_split] = mapping
+
+    validators = sequencers_data.get("validators", [])
+    updates = 0
+    changes = []
+
+    for validator in validators:
+        current_coinbase = validator.get("coinbase", "")
+        normalized_coinbase = normalize_address(current_coinbase)
+
+        matching_mapping = mapping_lookup.get(normalized_coinbase)
+        if matching_mapping:
+            new_coinbase = matching_mapping["split_contract"]
+
+            if normalize_address(new_coinbase) != normalized_coinbase:
+                changes.append(
+                    {
+                        "attester": matching_mapping["attester_address"],
+                        "old_coinbase": current_coinbase,
+                        "new_coinbase": new_coinbase,
+                    }
+                )
+                validator["coinbase"] = new_coinbase
+                updates += 1
+
+    if updates > 0:
+        success, error = save_sequencers(sequencers_data)
+        if not success:
+            return 0, [], error
+        logger.info("Updated %s coinbase addresses in sequencers.json", updates)
+
+    return updates, changes, None
+
+
+def format_amount(amount_wei: str) -> str:
+    """Format wei amount to human-readable AZTEC tokens."""
+    try:
+        amount = int(amount_wei) / 10**18
+        return f"{amount:,.0f}"
+    except (TypeError, ValueError):
+        return amount_wei
+
+
+def send_update_notification(
+    changes: list[dict[str, Any]],
+    provider_name: str,
+    total_staked: str,
+) -> None:
+    """Send Slack notification about coinbase updates."""
+    if not changes:
+        return
+
+    change_lines = []
+    for change in changes:
+        attester = change["attester"]
+        change_lines.append(
+            f"- Attester: `{attester[:10]}...{attester[-8:]}`\n"
+            f"  Split Contract: `{change['new_coinbase']}`"
+        )
+
+    message = (
+        "Aztec Coinbase Update\n\n"
+        f"Provider: {provider_name} (ID: {PROVIDER_ID})\n"
+        f"Total Staked: {format_amount(total_staked)} AZTEC\n\n"
+        f"{len(changes)} coinbase address(es) updated:\n\n"
+        + "\n\n".join(change_lines)
+        + "\n\nsequencers.json has been automatically updated.\n"
+        + "The validator will pick up the new coinbase via hot-reload."
+    )
+
+    send_slack_notification(message)
+
+
+def send_new_delegation_notification(new_mappings: list[dict[str, Any]], provider_name: str) -> None:
+    """Send Slack notification about new delegations detected."""
+    if not new_mappings:
+        return
+
+    delegation_lines = []
+    for mapping in new_mappings:
+        attester = mapping["attester_address"]
+        delegation_lines.append(
+            f"- Attester: `{attester[:10]}...{attester[-8:]}`\n"
+            f"  Split Contract: `{mapping['split_contract']}`\n"
+            f"  Staked: {format_amount(mapping['staked_amount'])} AZTEC"
+        )
+
+    message = (
+        "New Aztec Delegation(s) Detected\n\n"
+        f"Provider: {provider_name} (ID: {PROVIDER_ID})\n\n"
+        f"{len(new_mappings)} new delegation(s):\n\n"
+        + "\n\n".join(delegation_lines)
+    )
+
+    send_slack_notification(message)
+
+
+def run_coinbase_check() -> bool:
+    """
+    Run one coinbase updater cycle.
+
+    Returns True if successful, False if there was an error.
+    """
+    logger.info("Running coinbase updater check for provider %s", PROVIDER_ID)
+
+    provider_data, error = fetch_provider_data()
+    if not provider_data:
+        COINBASE_UPDATE_ERRORS.labels(PROVIDER_ID).inc()
+        COINBASE_UPDATE_UP.labels(PROVIDER_ID).set(0)
+        send_error_alert("API Fetch Failed", error or "Unknown error")
+        logger.warning("Could not fetch provider data, will retry next cycle")
+        return False
+
+    provider_name = provider_data.get("name", f"Provider {PROVIDER_ID}")
+    total_staked = provider_data.get("totalStaked", "0")
+    delegators = provider_data.get("delegators", 0)
+
+    logger.info(
+        "Provider: %s, Delegators: %s, Total Staked: %s AZTEC",
+        provider_name,
+        delegators,
+        format_amount(total_staked),
+    )
+
+    state = load_state()
+    all_mappings, new_or_changed = process_stakes(provider_data, state)
+
+    logger.info("Found %s total stakes, %s new/changed", len(all_mappings), len(new_or_changed))
+    save_mappings(all_mappings)
+
+    if new_or_changed:
+        send_new_delegation_notification(new_or_changed, provider_name)
+
+    if all_mappings:
+        updates, changes, error = update_sequencers_coinbase(all_mappings)
+
+        if error:
+            COINBASE_UPDATE_ERRORS.labels(PROVIDER_ID).inc()
+            COINBASE_UPDATE_UP.labels(PROVIDER_ID).set(0)
+            send_error_alert("File Operation Failed", error)
+            return False
+
+        if changes:
+            logger.info("Made %s coinbase updates", updates)
+            COINBASE_UPDATES_TOTAL.labels(PROVIDER_ID).inc(updates)
+            send_update_notification(changes, provider_name, total_staked)
+        else:
+            logger.debug("No coinbase updates needed")
+
+    save_state(state)
+    COINBASE_UPDATE_LAST_SUCCESS.labels(PROVIDER_ID).set(time.time())
+    COINBASE_UPDATE_UP.labels(PROVIDER_ID).set(1)
+    send_recovery_alert()
+
+    logger.info("Coinbase updater check complete")
+    return True
 
 
 def parse_rpc_urls(raw_urls: str) -> list[str]:
@@ -133,7 +581,7 @@ def fetch_provider_queue_length(
     raise RuntimeError(f"all configured L1 RPC URLs failed: {last_error}")
 
 
-def run_check() -> bool:
+def run_provider_queue_check() -> bool:
     """Run one provider queue poll and update metrics."""
     provider_id = int(PROVIDER_ID)
     rpc_urls = parse_rpc_urls(L1_RPC_URL)
@@ -157,7 +605,7 @@ def run_check() -> bool:
 
 
 def validate_config() -> None:
-    """Validate required config before serving metrics."""
+    """Validate required config before starting monitor loops."""
     if not PROVIDER_ID:
         logger.error("PROVIDER_ID is required")
         sys.exit(1)
@@ -180,28 +628,58 @@ def validate_config() -> None:
         logger.error("Invalid provider queue contract address: %s", PROVIDER_QUEUE_CONTRACT_ADDRESS)
         sys.exit(1)
 
+    if not STAKING_API_URL:
+        logger.warning("STAKING_API_URL is not configured; coinbase updater checks will fail")
+
+    if not Path(KEYSTORE_PATH).exists():
+        logger.warning("Keystore path does not exist: %s", KEYSTORE_PATH)
+
+    if not Path(DATA_PATH).exists():
+        logger.warning("Data path does not exist: %s", DATA_PATH)
+
 
 def main() -> None:
     """Main entry point."""
     logger.info("=" * 60)
     logger.info("Aztec Provider Monitor starting")
     logger.info("Provider ID: %s", PROVIDER_ID)
+    logger.info("API URL: %s", STAKING_API_URL)
     logger.info("Network: %s", NETWORK)
-    logger.info("Poll Interval: %ss", MONITOR_POLL_INTERVAL)
+    logger.info("Monitor Poll Interval: %ss", MONITOR_POLL_INTERVAL)
     logger.info("Metrics Port: %s", METRICS_PORT)
     logger.info("Provider Queue Contract: %s", PROVIDER_QUEUE_CONTRACT_ADDRESS)
+    logger.info("Keystore Path: %s", KEYSTORE_PATH)
+    logger.info("Data Path: %s", DATA_PATH)
+    logger.info("Slack Notifications: %s", "Enabled" if SLACK_WEBHOOK_URL else "Disabled")
+    logger.info("Error Alert Threshold: %s consecutive failures", ERROR_ALERT_THRESHOLD)
+    logger.info("Error Alert Cooldown: %ss", ERROR_ALERT_COOLDOWN)
     logger.info("=" * 60)
 
     validate_config()
 
+    COINBASE_UPDATE_UP.labels(PROVIDER_ID).set(0)
     PROVIDER_QUEUE_UP.labels(PROVIDER_ID).set(0)
     start_http_server(METRICS_PORT)
     logger.info("Prometheus metrics server started on :%s", METRICS_PORT)
 
+    next_coinbase_check = 0.0
+    next_provider_queue_check = 0.0
+
     while True:
-        run_check()
-        logger.info("Sleeping for %s seconds", MONITOR_POLL_INTERVAL)
-        time.sleep(MONITOR_POLL_INTERVAL)
+        now = time.time()
+
+        if now >= next_coinbase_check:
+            run_coinbase_check()
+            next_coinbase_check = time.time() + MONITOR_POLL_INTERVAL
+
+        if now >= next_provider_queue_check:
+            run_provider_queue_check()
+            next_provider_queue_check = time.time() + MONITOR_POLL_INTERVAL
+
+        next_check = min(next_coinbase_check, next_provider_queue_check)
+        sleep_seconds = max(1, min(60, int(next_check - time.time())))
+        logger.debug("Sleeping for %s seconds", sleep_seconds)
+        time.sleep(sleep_seconds)
 
 
 if __name__ == "__main__":

--- a/provider-monitor/requirements.txt
+++ b/provider-monitor/requirements.txt
@@ -1,2 +1,3 @@
 prometheus_client>=0.20.0
+requests>=2.28.0
 web3>=6.0.0

--- a/provider-monitor/test_monitor.py
+++ b/provider-monitor/test_monitor.py
@@ -1,28 +1,234 @@
 #!/usr/bin/env python3
 """Unit tests for the Aztec Provider Monitor."""
 
+import json
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+TEST_KEYSTORE_DIR = tempfile.mkdtemp()
+TEST_DATA_DIR = tempfile.mkdtemp()
 
-os.environ["PROVIDER_ID"] = "74"
+os.environ["KEYSTORE_PATH"] = TEST_KEYSTORE_DIR
+os.environ["DATA_PATH"] = TEST_DATA_DIR
+os.environ["PROVIDER_ID"] = "123"
+os.environ["STAKING_API_URL"] = "https://example.com/api"
 os.environ["L1_RPC_URL"] = "https://rpc-one.example, https://rpc-two.example"
 os.environ["NETWORK"] = "mainnet"
+os.environ["SLACK_WEBHOOK_URL"] = ""
 os.environ["LOG_LEVEL"] = "ERROR"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import monitor
 
+MOCK_PROVIDER_DATA = {
+    "id": 123,
+    "name": "TestProvider",
+    "totalStaked": "1600000000000000000000000",
+    "delegators": 8,
+    "stakes": [
+        {
+            "attesterAddress": "0x1111111111111111111111111111111111111111",
+            "splitContractAddress": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "stakedAmount": "200000000000000000000000",
+            "stakerAddress": "0xDelegator1",
+            "txHash": "0xTx1",
+            "blockNumber": "1000",
+        },
+        {
+            "attesterAddress": "0x2222222222222222222222222222222222222222",
+            "splitContractAddress": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            "stakedAmount": "200000000000000000000000",
+            "stakerAddress": "0xDelegator2",
+            "txHash": "0xTx2",
+            "blockNumber": "1001",
+        },
+        {
+            "attesterAddress": "0x3333333333333333333333333333333333333333",
+            "splitContractAddress": "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            "stakedAmount": "200000000000000000000000",
+            "stakerAddress": "0xDelegator3",
+            "txHash": "0xTx3",
+            "blockNumber": "1002",
+        },
+    ],
+}
+
+MOCK_SEQUENCERS = {
+    "schemaVersion": 1,
+    "validators": [
+        {
+            "attester": {"eth": "0xAttesterKey1", "bls": "0xBLSKey1"},
+            "publisher": "0xPublisher1",
+            "feeRecipient": "0x0000000000000000000000000000000000000000",
+            "coinbase": "0x1111111111111111111111111111111111111111",
+        },
+        {
+            "attester": {"eth": "0xAttesterKey2", "bls": "0xBLSKey2"},
+            "publisher": "0xPublisher2",
+            "feeRecipient": "0x0000000000000000000000000000000000000000",
+            "coinbase": "0x2222222222222222222222222222222222222222",
+        },
+        {
+            "attester": {"eth": "0xAttesterKey3", "bls": "0xBLSKey3"},
+            "publisher": "0xPublisher3",
+            "feeRecipient": "0x0000000000000000000000000000000000000000",
+            "coinbase": "0x4444444444444444444444444444444444444444",
+        },
+    ],
+}
+
 
 class ProviderMonitorTests(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(TEST_KEYSTORE_DIR)
+        shutil.rmtree(TEST_DATA_DIR)
+
+    def setUp(self):
+        sequencers_file = Path(TEST_KEYSTORE_DIR) / "sequencers.json"
+        with open(sequencers_file, "w") as file_handle:
+            json.dump(MOCK_SEQUENCERS, file_handle, indent=2)
+
+        for path in (monitor.STATE_FILE, monitor.MAPPINGS_FILE):
+            if path.exists():
+                path.unlink()
+
+        monitor.error_state = {
+            "consecutive_failures": 0,
+            "last_error_alert_time": 0,
+            "last_error_type": None,
+            "was_in_error_state": False,
+        }
+
     def test_mainnet_default_uses_staking_registry(self):
         self.assertEqual(
             monitor.PROVIDER_QUEUE_CONTRACT_ADDRESS,
             "0x042dF8f42790d6943F41C25C2132400fd727f452",
         )
+
+    def test_normalize_address(self):
+        self.assertEqual(monitor.normalize_address("0xABCD"), "0xabcd")
+        self.assertEqual(monitor.normalize_address("0xabcd"), "0xabcd")
+        self.assertEqual(monitor.normalize_address(""), "")
+        self.assertEqual(monitor.normalize_address(None), "")
+
+    def test_format_amount(self):
+        self.assertEqual(monitor.format_amount("200000000000000000000000"), "200,000")
+        self.assertEqual(monitor.format_amount("1600000000000000000000000"), "1,600,000")
+        self.assertEqual(monitor.format_amount("invalid"), "invalid")
+
+    def test_process_stakes_tracks_new_and_changed_mappings(self):
+        state = {"known_stakes": {}, "last_updated": None}
+        all_mappings, new_or_changed = monitor.process_stakes(MOCK_PROVIDER_DATA, state)
+
+        self.assertEqual(len(all_mappings), 3)
+        self.assertEqual(len(new_or_changed), 3)
+        self.assertEqual(all_mappings[0]["previous_split_contract"], "")
+
+        _, new_or_changed_again = monitor.process_stakes(MOCK_PROVIDER_DATA, state)
+        self.assertEqual(len(new_or_changed_again), 0)
+        self.assertEqual(state["known_stakes"]["0x1111111111111111111111111111111111111111"], "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+    def test_update_sequencers_coinbase(self):
+        mappings = [
+            {
+                "attester_address": "0x1111111111111111111111111111111111111111",
+                "split_contract": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            },
+            {
+                "attester_address": "0x2222222222222222222222222222222222222222",
+                "split_contract": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            },
+            {
+                "attester_address": "0x3333333333333333333333333333333333333333",
+                "split_contract": "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            },
+        ]
+
+        updates, changes, error = monitor.update_sequencers_coinbase(mappings)
+
+        self.assertIsNone(error)
+        self.assertEqual(updates, 2)
+        self.assertEqual(len(changes), 2)
+
+        with open(Path(TEST_KEYSTORE_DIR) / "sequencers.json", "r") as file_handle:
+            updated_data = json.load(file_handle)
+
+        validators = updated_data["validators"]
+        self.assertEqual(validators[0]["coinbase"], "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        self.assertEqual(validators[1]["coinbase"], "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+        self.assertEqual(validators[2]["coinbase"], "0x4444444444444444444444444444444444444444")
+
+    def test_update_sequencers_coinbase_updates_changed_split_contract(self):
+        sequencers = MOCK_SEQUENCERS.copy()
+        sequencers["validators"] = [validator.copy() for validator in MOCK_SEQUENCERS["validators"]]
+        sequencers["validators"][0]["coinbase"] = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+        with open(Path(TEST_KEYSTORE_DIR) / "sequencers.json", "w") as file_handle:
+            json.dump(sequencers, file_handle, indent=2)
+
+        mappings = [
+            {
+                "attester_address": "0x1111111111111111111111111111111111111111",
+                "split_contract": "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+                "previous_split_contract": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            },
+        ]
+
+        updates, changes, error = monitor.update_sequencers_coinbase(mappings)
+
+        self.assertIsNone(error)
+        self.assertEqual(updates, 1)
+        self.assertEqual(changes[0]["attester"], "0x1111111111111111111111111111111111111111")
+        self.assertEqual(changes[0]["old_coinbase"], "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        self.assertEqual(changes[0]["new_coinbase"], "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD")
+
+        with open(Path(TEST_KEYSTORE_DIR) / "sequencers.json", "r") as file_handle:
+            updated_data = json.load(file_handle)
+
+        self.assertEqual(
+            updated_data["validators"][0]["coinbase"],
+            "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+        )
+
+    def test_state_persistence(self):
+        test_state = {
+            "known_stakes": {"0xtest": "0xsplit"},
+            "last_updated": None,
+        }
+        monitor.save_state(test_state)
+
+        loaded_state = monitor.load_state()
+
+        self.assertIn("0xtest", loaded_state["known_stakes"])
+        self.assertEqual(loaded_state["known_stakes"]["0xtest"], "0xsplit")
+        self.assertIsNotNone(loaded_state["last_updated"])
+
+    def test_run_coinbase_check_with_mock_provider_data(self):
+        with patch.object(monitor, "fetch_provider_data", return_value=(MOCK_PROVIDER_DATA, None)):
+            self.assertTrue(monitor.run_coinbase_check())
+
+        self.assertTrue(monitor.STATE_FILE.exists())
+        self.assertTrue(monitor.MAPPINGS_FILE.exists())
+        self.assertEqual(monitor.COINBASE_UPDATE_UP.labels("123")._value.get(), 1)
+
+        with open(monitor.MAPPINGS_FILE, "r") as file_handle:
+            mappings_data = json.load(file_handle)
+
+        self.assertEqual(len(mappings_data["mappings"]), 3)
+
+    def test_run_coinbase_check_api_error(self):
+        with patch.object(monitor, "fetch_provider_data", return_value=(None, "Connection timeout")):
+            self.assertFalse(monitor.run_coinbase_check())
+
+        self.assertEqual(monitor.error_state["consecutive_failures"], 1)
+        self.assertEqual(monitor.COINBASE_UPDATE_UP.labels("123")._value.get(), 0)
 
     def test_parse_rpc_urls(self):
         self.assertEqual(
@@ -59,25 +265,29 @@ class ProviderMonitorTests(unittest.TestCase):
         self.assertEqual(value, 250)
         self.assertEqual(call_queue_length.call_count, 2)
 
-    def test_run_check_sets_success_metrics(self):
+    def test_run_provider_queue_check_sets_success_metrics(self):
         with patch.object(monitor, "fetch_provider_queue_length", return_value=250):
-            self.assertTrue(monitor.run_check())
+            self.assertTrue(monitor.run_provider_queue_check())
 
         self.assertEqual(
-            monitor.PROVIDER_QUEUE_LENGTH.labels("74")._value.get(),
+            monitor.PROVIDER_QUEUE_LENGTH.labels("123")._value.get(),
             250,
         )
         self.assertEqual(
-            monitor.PROVIDER_QUEUE_UP.labels("74")._value.get(),
+            monitor.PROVIDER_QUEUE_UP.labels("123")._value.get(),
             1,
         )
 
-    def test_run_check_sets_failure_metric(self):
-        with patch.object(monitor, "fetch_provider_queue_length", side_effect=RuntimeError("boom")):
-            self.assertFalse(monitor.run_check())
+    def test_run_provider_queue_check_sets_failure_metric(self):
+        with patch.object(
+            monitor,
+            "fetch_provider_queue_length",
+            side_effect=RuntimeError("boom"),
+        ):
+            self.assertFalse(monitor.run_provider_queue_check())
 
         self.assertEqual(
-            monitor.PROVIDER_QUEUE_UP.labels("74")._value.get(),
+            monitor.PROVIDER_QUEUE_UP.labels("123")._value.get(),
             0,
         )
 


### PR DESCRIPTION
## Summary
- Keep the provider monitor as a single service that updates coinbase addresses and exports Prometheus metrics
- Preserve existing coinbase updater state while adding provider queue and updater health metrics
- Use MONITOR_POLL_INTERVAL=10800 as the single monitor cadence and cover split-contract changes with tests