### PR TITLE
BCE-10711 add provider key monitor

### DIFF
--- a/default.env
+++ b/default.env
@@ -82,6 +82,16 @@ MONITOR_POLL_INTERVAL=300
 # Slack webhook URL for notifications (optional)
 SLACK_WEBHOOK_URL=
 
+# Provider Key Monitor - read-only Prometheus exporter for provider queue length
+# Network contract defaults to use for provider key monitoring
+PROVIDER_KEY_MONITOR_NETWORK=mainnet
+# Optional queue contract override. Leave empty to use the network default.
+PROVIDER_QUEUE_CONTRACT_ADDRESS=
+# How often to poll provider queue length (seconds)
+PROVIDER_KEY_MONITOR_POLL_INTERVAL=300
+# Provider key monitor Prometheus metrics port
+PROVIDER_KEY_MONITOR_METRICS_PORT=9102
+
 # You can pin the version of aztec-prover-docker here
 SCRIPT_TAG=
 

--- a/provider-key-monitor.yml
+++ b/provider-key-monitor.yml
@@ -1,0 +1,27 @@
+x-logging: &logging
+  logging:
+    driver: json-file
+    options:
+      max-size: 100m
+      max-file: "3"
+      tag: '{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}'
+
+services:
+  provider-key-monitor:
+    restart: unless-stopped
+    build:
+      context: ./provider-key-monitor
+      dockerfile: Dockerfile
+    environment:
+      PROVIDER_ID: ${PROVIDER_ID}
+      L1_RPC_URL: ${L1_RPC}
+      NETWORK: ${PROVIDER_KEY_MONITOR_NETWORK:-mainnet}
+      PROVIDER_QUEUE_CONTRACT_ADDRESS: ${PROVIDER_QUEUE_CONTRACT_ADDRESS:-}
+      PROVIDER_KEY_MONITOR_POLL_INTERVAL: ${PROVIDER_KEY_MONITOR_POLL_INTERVAL:-300}
+      METRICS_PORT: ${PROVIDER_KEY_MONITOR_METRICS_PORT:-9102}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    labels:
+      - metrics.scrape=true
+      - metrics.path=/metrics
+      - metrics.port=${PROVIDER_KEY_MONITOR_METRICS_PORT:-9102}
+    <<: *logging

--- a/provider-key-monitor/Dockerfile
+++ b/provider-key-monitor/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY monitor.py .
+
+CMD ["python", "-u", "monitor.py"]

--- a/provider-key-monitor/README.md
+++ b/provider-key-monitor/README.md
@@ -1,0 +1,43 @@
+# Aztec Provider Key Monitor
+
+Read-only Prometheus exporter for Aztec provider sequencer key availability.
+
+The monitor polls the Aztec staking registry for `getProviderQueueLength(<provider_id>)` and exposes raw metrics for Grafana. It does not update `sequencers.json`, does not change coinbase addresses, and does not send Slack notifications.
+
+## Metrics
+
+| Metric | Description |
+| --- | --- |
+| `aztec_provider_sequencer_key_queue_length{provider_id="74"}` | Current provider sequencer key queue length |
+| `aztec_provider_queue_last_success_timestamp{provider_id="74"}` | Unix timestamp of the last successful poll |
+| `aztec_provider_queue_poll_errors_total{provider_id="74"}` | Total failed poll attempts |
+| `aztec_provider_queue_up{provider_id="74"}` | `1` when the latest poll succeeded, otherwise `0` |
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PROVIDER_ID` | none | Aztec staking provider ID |
+| `L1_RPC` | none | Comma-separated L1 RPC URLs, mapped to `L1_RPC_URL` in the container |
+| `PROVIDER_KEY_MONITOR_NETWORK` | `mainnet` | Network contract defaults to use |
+| `PROVIDER_QUEUE_CONTRACT_ADDRESS` | mainnet staking registry | Optional override for the queue contract |
+| `PROVIDER_KEY_MONITOR_POLL_INTERVAL` | `300` | Seconds between queue polls |
+| `PROVIDER_KEY_MONITOR_METRICS_PORT` | `9102` | Prometheus scrape port |
+
+## Run
+
+Add `provider-key-monitor.yml` to `COMPOSE_FILE` with `validator.yml`:
+
+```env
+COMPOSE_FILE=validator.yml:coinbase-monitor.yml:provider-key-monitor.yml:ext-network.yml
+PROVIDER_ID=74
+PROVIDER_KEY_MONITOR_NETWORK=mainnet
+PROVIDER_KEY_MONITOR_POLL_INTERVAL=300
+PROVIDER_KEY_MONITOR_METRICS_PORT=9102
+```
+
+Start only the sidecar:
+
+```sh
+docker compose up -d --build provider-key-monitor
+```

--- a/provider-key-monitor/monitor.py
+++ b/provider-key-monitor/monitor.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Read-only Aztec provider key availability exporter.
+
+Polls the Aztec staking registry for provider queue length and exposes raw
+Prometheus metrics. Alert thresholds and routing are owned by Grafana.
+"""
+
+import logging
+import os
+import sys
+import time
+from collections.abc import Iterable
+
+from prometheus_client import Counter, Gauge, start_http_server
+from web3 import Web3
+
+PROVIDER_ID = os.getenv("PROVIDER_ID", "")
+L1_RPC_URL = os.getenv("L1_RPC_URL", "")
+NETWORK = os.getenv("NETWORK", "mainnet").lower()
+POLL_INTERVAL = int(os.getenv("PROVIDER_KEY_MONITOR_POLL_INTERVAL", "300"))
+METRICS_PORT = int(os.getenv("METRICS_PORT", "9102"))
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+RPC_TIMEOUT = int(os.getenv("RPC_TIMEOUT", "30"))
+
+CONTRACTS = {
+    "mainnet": {
+        "staking_registry": "0x042dF8f42790d6943F41C25C2132400fd727f452",
+    },
+}
+
+DEFAULT_QUEUE_CONTRACT_ADDRESS = CONTRACTS.get(NETWORK, {}).get("staking_registry", "")
+PROVIDER_QUEUE_CONTRACT_ADDRESS = (
+    os.getenv("PROVIDER_QUEUE_CONTRACT_ADDRESS") or DEFAULT_QUEUE_CONTRACT_ADDRESS
+)
+
+QUEUE_LENGTH_SIGNATURES = (
+    "getProviderQueueLength(uint256)",
+    "getProviderQueueLength(uint32)",
+    "getProviderQueueLength(uint16)",
+    "getProviderQueueLength(uint8)",
+)
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+PROVIDER_QUEUE_LENGTH = Gauge(
+    "aztec_provider_sequencer_key_queue_length",
+    "Current available sequencer key queue length for an Aztec provider",
+    ["provider_id"],
+)
+PROVIDER_QUEUE_LAST_SUCCESS = Gauge(
+    "aztec_provider_queue_last_success_timestamp",
+    "Unix timestamp of the last successful Aztec provider queue poll",
+    ["provider_id"],
+)
+PROVIDER_QUEUE_POLL_ERRORS = Counter(
+    "aztec_provider_queue_poll_errors_total",
+    "Total number of Aztec provider queue poll errors",
+    ["provider_id"],
+)
+PROVIDER_QUEUE_UP = Gauge(
+    "aztec_provider_queue_up",
+    "Whether the Aztec provider queue poll succeeded on the latest attempt (1=yes, 0=no)",
+    ["provider_id"],
+)
+
+
+def parse_rpc_urls(raw_urls: str) -> list[str]:
+    """Split comma-separated RPC URLs and drop empty entries."""
+    return [url.strip() for url in raw_urls.split(",") if url.strip()]
+
+
+def build_call_data(signature: str, provider_id: int) -> str:
+    """Build calldata for a provider queue length call."""
+    selector = Web3.keccak(text=signature)[:4].hex()
+    argument = provider_id.to_bytes(32, byteorder="big").hex()
+    return f"0x{selector}{argument}"
+
+
+def decode_uint256(result: bytes) -> int:
+    """Decode a uint256 eth_call result."""
+    raw = bytes(result)
+    if len(raw) < 32:
+        raise ValueError(f"expected at least 32 bytes, got {len(raw)}")
+    return int.from_bytes(raw[-32:], byteorder="big")
+
+
+def call_queue_length(
+    rpc_url: str,
+    contract_address: str,
+    provider_id: int,
+    signatures: Iterable[str] = QUEUE_LENGTH_SIGNATURES,
+) -> int:
+    """Call getProviderQueueLength through one RPC URL."""
+    web3 = Web3(Web3.HTTPProvider(rpc_url, request_kwargs={"timeout": RPC_TIMEOUT}))
+    checksum_address = Web3.to_checksum_address(contract_address)
+    last_error: Exception | None = None
+
+    for signature in signatures:
+        try:
+            call_data = build_call_data(signature, provider_id)
+            result = web3.eth.call({"to": checksum_address, "data": call_data})
+            value = decode_uint256(result)
+            logger.debug("Provider queue call succeeded with signature %s", signature)
+            return value
+        except Exception as exc:
+            last_error = exc
+            logger.debug("Provider queue call failed with signature %s: %s", signature, exc)
+
+    raise RuntimeError(f"all provider queue call signatures failed: {last_error}")
+
+
+def fetch_provider_queue_length(
+    rpc_urls: Iterable[str],
+    contract_address: str,
+    provider_id: int,
+) -> int:
+    """Fetch provider queue length, trying configured RPC URLs in order."""
+    last_error: Exception | None = None
+
+    for rpc_url in rpc_urls:
+        try:
+            return call_queue_length(rpc_url, contract_address, provider_id)
+        except Exception as exc:
+            last_error = exc
+            logger.warning("Provider queue poll failed via %s: %s", rpc_url, exc)
+
+    raise RuntimeError(f"all configured L1 RPC URLs failed: {last_error}")
+
+
+def run_check() -> bool:
+    """Run one provider queue poll and update metrics."""
+    provider_id = int(PROVIDER_ID)
+    rpc_urls = parse_rpc_urls(L1_RPC_URL)
+
+    try:
+        queue_length = fetch_provider_queue_length(
+            rpc_urls,
+            PROVIDER_QUEUE_CONTRACT_ADDRESS,
+            provider_id,
+        )
+        PROVIDER_QUEUE_LENGTH.labels(PROVIDER_ID).set(queue_length)
+        PROVIDER_QUEUE_LAST_SUCCESS.labels(PROVIDER_ID).set(time.time())
+        PROVIDER_QUEUE_UP.labels(PROVIDER_ID).set(1)
+        logger.info("Provider %s queue length: %s", PROVIDER_ID, queue_length)
+        return True
+    except Exception as exc:
+        PROVIDER_QUEUE_POLL_ERRORS.labels(PROVIDER_ID).inc()
+        PROVIDER_QUEUE_UP.labels(PROVIDER_ID).set(0)
+        logger.error("Provider queue poll failed: %s", exc)
+        return False
+
+
+def validate_config() -> None:
+    """Validate required config before serving metrics."""
+    if not PROVIDER_ID:
+        logger.error("PROVIDER_ID is required")
+        sys.exit(1)
+
+    try:
+        int(PROVIDER_ID)
+    except ValueError:
+        logger.error("PROVIDER_ID must be an integer, got %s", PROVIDER_ID)
+        sys.exit(1)
+
+    if not parse_rpc_urls(L1_RPC_URL):
+        logger.error("L1_RPC_URL is required")
+        sys.exit(1)
+
+    if not PROVIDER_QUEUE_CONTRACT_ADDRESS:
+        logger.error("No provider queue contract address configured for network %s", NETWORK)
+        sys.exit(1)
+
+    if not Web3.is_address(PROVIDER_QUEUE_CONTRACT_ADDRESS):
+        logger.error("Invalid provider queue contract address: %s", PROVIDER_QUEUE_CONTRACT_ADDRESS)
+        sys.exit(1)
+
+
+def main() -> None:
+    """Start metrics server and poll forever."""
+    logger.info("=" * 60)
+    logger.info("Aztec Provider Key Monitor starting")
+    logger.info("Provider ID: %s", PROVIDER_ID)
+    logger.info("Network: %s", NETWORK)
+    logger.info("Poll Interval: %ss", POLL_INTERVAL)
+    logger.info("Metrics Port: %s", METRICS_PORT)
+    logger.info("Provider Queue Contract: %s", PROVIDER_QUEUE_CONTRACT_ADDRESS)
+    logger.info("=" * 60)
+
+    validate_config()
+
+    PROVIDER_QUEUE_UP.labels(PROVIDER_ID).set(0)
+    start_http_server(METRICS_PORT)
+    logger.info("Prometheus metrics server started on :%s", METRICS_PORT)
+
+    while True:
+        run_check()
+        logger.info("Sleeping for %s seconds", POLL_INTERVAL)
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/provider-key-monitor/requirements.txt
+++ b/provider-key-monitor/requirements.txt
@@ -1,0 +1,2 @@
+prometheus_client>=0.20.0
+web3>=6.0.0

--- a/provider-key-monitor/test_monitor.py
+++ b/provider-key-monitor/test_monitor.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Unit tests for the Aztec provider key monitor."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+os.environ["PROVIDER_ID"] = "74"
+os.environ["L1_RPC_URL"] = "https://rpc-one.example, https://rpc-two.example"
+os.environ["NETWORK"] = "mainnet"
+os.environ["LOG_LEVEL"] = "ERROR"
+
+import monitor
+
+
+class ProviderKeyMonitorTests(unittest.TestCase):
+    def test_mainnet_default_uses_staking_registry(self):
+        self.assertEqual(
+            monitor.PROVIDER_QUEUE_CONTRACT_ADDRESS,
+            "0x042dF8f42790d6943F41C25C2132400fd727f452",
+        )
+
+    def test_parse_rpc_urls(self):
+        self.assertEqual(
+            monitor.parse_rpc_urls(" https://a.example,https://b.example, "),
+            ["https://a.example", "https://b.example"],
+        )
+
+    def test_build_call_data(self):
+        call_data = monitor.build_call_data("getProviderQueueLength(uint256)", 74)
+
+        self.assertTrue(call_data.startswith("0x"))
+        self.assertEqual(len(call_data), 10 + 64)
+        self.assertTrue(call_data.endswith(f"{74:064x}"))
+
+    def test_decode_uint256(self):
+        raw = (250).to_bytes(32, byteorder="big")
+
+        self.assertEqual(monitor.decode_uint256(raw), 250)
+
+    def test_decode_uint256_rejects_short_result(self):
+        with self.assertRaises(ValueError):
+            monitor.decode_uint256(b"\x01")
+
+    def test_fetch_provider_queue_length_tries_next_rpc(self):
+        with patch.object(monitor, "call_queue_length") as call_queue_length:
+            call_queue_length.side_effect = [RuntimeError("primary failed"), 250]
+
+            value = monitor.fetch_provider_queue_length(
+                ["https://rpc-one.example", "https://rpc-two.example"],
+                monitor.PROVIDER_QUEUE_CONTRACT_ADDRESS,
+                74,
+            )
+
+        self.assertEqual(value, 250)
+        self.assertEqual(call_queue_length.call_count, 2)
+
+    def test_run_check_sets_success_metrics(self):
+        with patch.object(monitor, "fetch_provider_queue_length", return_value=250):
+            self.assertTrue(monitor.run_check())
+
+        self.assertEqual(
+            monitor.PROVIDER_QUEUE_LENGTH.labels("74")._value.get(),
+            250,
+        )
+        self.assertEqual(
+            monitor.PROVIDER_QUEUE_UP.labels("74")._value.get(),
+            1,
+        )
+
+    def test_run_check_sets_failure_metric(self):
+        with patch.object(monitor, "fetch_provider_queue_length", side_effect=RuntimeError("boom")):
+            self.assertFalse(monitor.run_check())
+
+        self.assertEqual(
+            monitor.PROVIDER_QUEUE_UP.labels("74")._value.get(),
+            0,
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())


### PR DESCRIPTION
## Summary
- add standalone read-only provider-key-monitor Prometheus exporter
- expose provider queue length metrics without editing sequencers.json or coinbase state
- add compose service, defaults, docs, and unit coverage