### PR TITLE
Remove deprecated features after v5 upgrade

### DIFF
--- a/validator.yml
+++ b/validator.yml
@@ -46,7 +46,6 @@ services:
       - --sequencer.keyStoreDirectory
       - /keystore
       - --node
-      - --archiver
       - --sequencer
     command: ${SEQUENCER_EXTRAS}
     <<: *logging


### PR DESCRIPTION
This pull request makes a small change to the `validator.yml` file, specifically removing the `--archiver` flag from the `services` section. This simplifies the service configuration.